### PR TITLE
add support for API URL env

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ command right away and reset the interval.
 		Default value of 10KB is equal to healthchecks.io instance's
 		ping body limit.
 	-api-url="https://hc-ping.com"
-		API URL. Defaults to healthchecks.io hosted service.
+		API URL. Takes precedence over HC_API_URL environment variable. Defaults to healthchecks.io hosted service.
 	-api-retries=2
 		Number of times an API request will be retried if it fails with
 		a transient error.

--- a/cmd/runitor/main.go
+++ b/cmd/runitor/main.go
@@ -40,7 +40,7 @@ var Version string = "HEAD"
 
 func main() {
 	var (
-		apiURL         = flag.String("api-url", internal.DefaultBaseURL, "API URL. Takes precedence over CHECK_API_URL environment variable")
+		apiURL         = flag.String("api-url", internal.DefaultBaseURL, "API URL. Takes precedence over HC_API_URL environment variable")
 		apiRetries     = flag.Int("api-retries", internal.DefaultRetries, "Number of times an API request will be retried if it fails with a transient error")
 		_apiTries      = flag.Int("api-tries", 0, "DEPRECATED (pending removal in v1.0.0): Use -api-retries")
 		apiTimeout     = flag.Duration("api-timeout", internal.DefaultTimeout, "Client timeout per request")
@@ -71,7 +71,7 @@ func main() {
 	}
 
 	if *apiURL == internal.DefaultBaseURL {
-		v, ok := os.LookupEnv("CHECK_API_URL")
+		v, ok := os.LookupEnv("HC_API_URL")
 		if ok && len(v) > 0 {
 			apiURL = &v
 		}

--- a/cmd/runitor/main.go
+++ b/cmd/runitor/main.go
@@ -40,7 +40,7 @@ var Version string = "HEAD"
 
 func main() {
 	var (
-		apiURL         = flag.String("api-url", internal.DefaultBaseURL, "API URL")
+		apiURL         = flag.String("api-url", internal.DefaultBaseURL, "API URL. Takes precedence over CHECK_API_URL environment variable")
 		apiRetries     = flag.Int("api-retries", internal.DefaultRetries, "Number of times an API request will be retried if it fails with a transient error")
 		_apiTries      = flag.Int("api-tries", 0, "DEPRECATED (pending removal in v1.0.0): Use -api-retries")
 		apiTimeout     = flag.Duration("api-timeout", internal.DefaultTimeout, "Client timeout per request")
@@ -68,6 +68,13 @@ func main() {
 		}
 
 		uuid = &v
+	}
+
+	if *apiURL == internal.DefaultBaseURL {
+		v, ok := os.LookupEnv("CHECK_API_URL")
+		if ok && len(v) > 0 {
+			apiURL = &v
+		}
 	}
 
 	if flag.NArg() < 1 {


### PR DESCRIPTION
Adds option for `CHECK_API_URL` environment variable. Similar to `CHECK_UUID`, it only overrides the passed argument if the argument equals the default base URL.