### PR TITLE
Add build option CGO_ENABLED=0

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -12,7 +12,7 @@ name="runitor"
 GO="${GO:-go}"
 
 build() {
-  ${GO} build -o "${BUILD_DIR}/" ./cmd/${name}
+  CGO_ENABLED=0 ${GO} build -o "${BUILD_DIR}/" ./cmd/${name}
 }
 
 build_dist() {
@@ -37,7 +37,7 @@ build_dist() {
   local out="${BUILD_DIR}/${name}-${ver}-${goos}-${goarch}${fn_suffix}"
 
 
-  ${GO} build -trimpath -ldflags="${ldflags}" -o "${out}" ./cmd/${name}
+  CGO_ENABLED=0 ${GO} build -trimpath -ldflags="${ldflags}" -o "${out}" ./cmd/${name}
   echo "${out}"
 }
 


### PR DESCRIPTION
Adds option for CGO_ENABLED=0. 
It would be nice to be able to run the runitor command in various environments such as alpine.