### PR TITLE
Change ping body limit default for hc-ping.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,11 @@ command right away and reset the interval.
 		Don't send start ping.
 	-no-output-in-ping=false
 		Don't send command's output in pings.
-	-ping-body-limit=10000
+	-ping-body-limit=10_000
 		If non-zero, truncate the ping body to its last N bytes,
 		including a truncation notice.
-		Default value of 10KB is equal to healthchecks.io instance's
-		ping body limit.
+		Default value for hc-ping.com instance is 100KB.
+		For everything else 10KB.
 	-api-url="https://hc-ping.com"
 		API URL. Takes precedence over HC_API_URL environment variable. Defaults to healthchecks.io hosted service.
 	-api-retries=2
@@ -144,7 +144,7 @@ command right away and reset the interval.
 
 * Pings can explicitly signal failure of execution so an alert can be send.
 
-* Pings can attach up to 10KB of logs. Runitor automatically handles truncation if needed.
+* Pings can attach up to 100KB of logs. Runitor automatically handles truncation if needed.
 
 * It can alert you via email, SMS, WhatsApp, Slack, and many more services.
 

--- a/cmd/runitor/main.go
+++ b/cmd/runitor/main.go
@@ -110,7 +110,7 @@ func main() {
 		silent         = flag.Bool("silent", false, "Don't capture command's stdout or stderr")
 		noStartPing    = flag.Bool("no-start-ping", false, "Don't send start ping")
 		noOutputInPing = flag.Bool("no-output-in-ping", false, "Don't send command's output in pings")
-		pingBodyLimit  = flag.Uint("ping-body-limit", 10000, "If non-zero, truncate the ping body to its last N bytes, including a truncation notice.")
+		pingBodyLimit  = flag.Uint("ping-body-limit", 10_000, "If non-zero, truncate the ping body to its last N bytes, including a truncation notice.")
 		version        = flag.Bool("version", false, "Show version")
 	)
 
@@ -160,6 +160,25 @@ func main() {
 		if v, ok := os.LookupEnv("HC_API_URL"); ok && len(v) > 0 {
 			apiURL = &v
 		}
+	}
+
+	pingBodyLimitFromArgs := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "ping-body-limit" {
+			pingBodyLimitFromArgs = true
+		}
+	})
+
+	// TODO(bdd):
+	// Conditionally increase the default ping body limit for the hosted
+	// healthchecks.io instance (hc-ping.com) unless one is explicitly
+	// passed via flags.
+	//
+	// This is temporary until a way to discover the instance limits land
+	// possibly as discussed in
+	// https://github.com/bdd/runitor/discussions/32#discussioncomment-2525494
+	if !pingBodyLimitFromArgs && *apiURL == internal.DefaultBaseURL {
+		*pingBodyLimit = 100_000
 	}
 
 	if flag.NArg() < 1 {


### PR DESCRIPTION
healthchecks.io instance increased the ping body limit[^1] from 10 to
100KB.

The open source distribution default is still 10KB[^2][^3].

[^1]: https://twitter.com/healthchecks_io/status/1511672152415690756
[^2]: https://github.com/healthchecks/healthchecks/blob/c1ac2ffc9caa11a08538cbe0de39f9b99c0e48cc/hc/settings.py#L163
[^3]: https://github.com/healthchecks/healthchecks/blob/d54dcb5ea65e744a00dbf867ab8888a4781bbff5/docker/.env#L35