### PR TITLE
Add Run Id* support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ command right away and reset the interval.
 	  If non-zero, periodically run command at specified interval
 	-no-output-in-ping
 	  Don't send command's output in pings
+	-no-run-id
+	  Don't generate and send a run id per run in pings
 	-no-start-ping
 	  Don't send start ping
 	-on-exec-fail value

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module bdd.fi/x/runitor
 
-go 1.18
+go 1.19

--- a/internal/api_test.go
+++ b/internal/api_test.go
@@ -13,7 +13,10 @@ import (
 	. "bdd.fi/x/runitor/internal"
 )
 
-const TestHandle string = "pingKey/testHandle"
+const (
+	TestHandle = "pingKey/testHandle"
+	TestRunId  = "00000000-1111-4000-a000-223344556677"
+)
 
 // Tests if APIClient makes requests with the expected method, content-type,
 // and user-agent.
@@ -49,7 +52,7 @@ func TestPostRequest(t *testing.T) {
 		UserAgent: expUA,
 	}
 
-	_, err := c.PingSuccess(TestHandle, nil)
+	_, err := c.PingSuccess(TestHandle, TestRunId, nil)
 	if err != nil {
 		t.Fatalf("expected successful Ping, got error: %+v", err)
 	}
@@ -105,7 +108,7 @@ func TestPostRetries(t *testing.T) {
 		Backoff: backoff,
 	}
 
-	_, err := c.PingSuccess(TestHandle, nil)
+	_, err := c.PingSuccess(TestHandle, TestRunId, nil)
 	if err != nil {
 		t.Fatalf("expected successful Ping, got error: %+v", err)
 	}
@@ -135,7 +138,7 @@ func TestPostNonRetriable(t *testing.T) {
 		Client:  ts.Client(),
 	}
 
-	_, err := c.PingSuccess(TestHandle, nil)
+	_, err := c.PingSuccess(TestHandle, TestRunId, nil)
 	if err == nil {
 		t.Errorf("expected PingSuccess to return non-nil error after non-retriable API response")
 	}
@@ -150,11 +153,11 @@ func TestPostURIs(t *testing.T) {
 	c := &APIClient{}
 
 	testCases := map[string]ping{
-		"/start": func() (*InstanceConfig, error) { return c.PingStart(TestHandle) },
-		"":       func() (*InstanceConfig, error) { return c.PingSuccess(TestHandle, nil) },
-		"/fail":  func() (*InstanceConfig, error) { return c.PingFail(TestHandle, nil) },
-		"/log":   func() (*InstanceConfig, error) { return c.PingLog(TestHandle, nil) },
-		"/42":    func() (*InstanceConfig, error) { return c.PingExitCode(TestHandle, 42, nil) },
+		"/start": func() (*InstanceConfig, error) { return c.PingStart(TestHandle, TestRunId) },
+		"":       func() (*InstanceConfig, error) { return c.PingSuccess(TestHandle, TestRunId, nil) },
+		"/fail":  func() (*InstanceConfig, error) { return c.PingFail(TestHandle, TestRunId, nil) },
+		"/log":   func() (*InstanceConfig, error) { return c.PingLog(TestHandle, TestRunId, nil) },
+		"/42":    func() (*InstanceConfig, error) { return c.PingExitCode(TestHandle, TestRunId, 42, nil) },
 	}
 
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -215,7 +218,7 @@ func TestPostReqHeaders(t *testing.T) {
 		ReqHeaders: expReqHeaders,
 	}
 
-	_, err := c.PingSuccess(TestHandle, nil)
+	_, err := c.PingSuccess(TestHandle, TestRunId, nil)
 	if err != nil {
 		t.Fatalf("expected successful Ping, got error: %+v", err)
 	}

--- a/internal/uuid.go
+++ b/internal/uuid.go
@@ -1,0 +1,37 @@
+// Copyright 2020 - 2022, Berk D. Demir and the runitor contributors
+// SPDX-License-Identifier: OBSD
+package internal
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+)
+
+const uuid4RandBytes = 128 / 8
+
+func NewUUID4() (string, error) {
+	rnd := make([]byte, uuid4RandBytes)
+	_, err := rand.Read(rnd)
+	if err != nil {
+		return "", err
+	}
+
+	rnd[6] = (rnd[6] & 0x0f) | 0x40 // version 4
+	rnd[8] = (rnd[8] & 0x3f) | 0x80 // variant 0b10
+
+	var str [2*uuid4RandBytes + 4]byte
+	//       \______________/ \_/
+	//              |          |_> 4 '-' separators
+	//              |____________> 2 hex digits per byte
+	hex.Encode(str[:], rnd[:4])
+	str[8] = '-'
+	hex.Encode(str[9:13], rnd[4:6])
+	str[13] = '-'
+	hex.Encode(str[14:18], rnd[6:8])
+	str[18] = '-'
+	hex.Encode(str[19:23], rnd[8:10])
+	str[23] = '-'
+	hex.Encode(str[24:], rnd[10:])
+
+	return string(str[:]), nil
+}

--- a/scripts/build
+++ b/scripts/build
@@ -32,7 +32,9 @@ if [[ ${GO} != "go" ]]; then
     # wanted go version is the default go.
     GO=go
   elif ! type -p "${GO}"; then
+    GOBIN=${GOBIN:-$(go env GOPATH | cut -d: -f1)/bin}
     go install "golang.org/dl/${GO}@latest"
+    GO="${GOBIN}/${GO}"
     "${GO}" download
   fi
 fi


### PR DESCRIPTION
A UUID-4 (grrr...) run id is generated for every run and sent with related pings, unless instructed otherwise with `-no-run-id` flag.

For use cases where runitor is in charge of periodically running a command (specified with `-every <duration>`), each run gets its own random UUID as expected.

There is no way for the user to supply the run ids, and I don't intend to add such functionality. Furthermore I may consider removing `-no-run-id` flag altogether.

[*] https://blog.healthchecks.io/2022/11/using-run-ids-to-track-run-times-of-overlapping-jobs/