### PR TITLE
Resend body on 307 redirect

### DIFF
--- a/internal/api_test.go
+++ b/internal/api_test.go
@@ -3,6 +3,7 @@
 package internal_test
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -335,8 +336,8 @@ func TestResubmitRingBufferBody(t *testing.T) {
 		if err != nil {
 			t.Errorf("could not read request body")
 		}
-		if string(reqBody) != string(body) {
-			t.Errorf("request body does not match expected body")
+		if !bytes.Equal(reqBody, body) {
+			t.Errorf("request body does not match expected body: %s", reqBody)
 		}
 		if r.URL.Path == "/redirect-target" {
 			pingReceived = true

--- a/internal/api_test.go
+++ b/internal/api_test.go
@@ -3,6 +3,8 @@
 package internal_test
 
 import (
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -280,5 +282,42 @@ func TestNewDefaultTransportWithResumption(t *testing.T) {
 	tr := NewDefaultTransportWithResumption()
 	if tr.TLSClientConfig == nil {
 		t.Errorf("TLSClientConfig is not set")
+	}
+}
+
+// Tests if Content-Length gets set correctly when a RingBuffer is used as
+// request body.
+func TestContentLengthForRingBufferBody(t *testing.T) {
+	t.Parallel()
+
+	body := []byte("Hello, World!")
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		v := r.Header.Get("Content-Length")
+		if v != fmt.Sprintf("%d", len(body)) {
+			t.Errorf("Content-Length header should be set to %d, but got %s", len(body), v)
+		}
+		reqBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("could not read request body")
+		}
+		if string(reqBody) != string(body) {
+			t.Errorf("request body does not match expected body")
+		}
+	}))
+
+	defer ts.Close()
+
+	c := &APIClient{
+		BaseURL: ts.URL,
+		Client:  ts.Client(),
+	}
+
+	rb := NewRingBuffer(100)
+	rb.Write(body)
+
+	_, err := c.PingSuccess(TestHandle, TestRunId, rb)
+	if err != nil {
+		t.Fatalf("ping failed: %+v", err)
 	}
 }


### PR DESCRIPTION
Before this change, 307 redirects cause errors:

~~~
--- FAIL: TestResubmitRingBufferBody (0.00s)
    api_test.go:361: ping failed: nonretriable error response: 307 Temporary Redirect
~~~

After this change, they work as intended.

Closes #79.