### PR TITLE
Add handling for HTTP 201 server responses

### DIFF
--- a/internal/api.go
+++ b/internal/api.go
@@ -198,6 +198,8 @@ Try:
 	switch {
 	case resp.StatusCode == http.StatusOK:
 		return
+	case resp.StatusCode == http.StatusCreated:
+		return
 	case retriableResponse(resp.StatusCode):
 		code := resp.StatusCode
 		text := http.StatusText(code)

--- a/internal/api_test.go
+++ b/internal/api_test.go
@@ -62,6 +62,27 @@ func TestPostRequest(t *testing.T) {
 	}
 }
 
+// Tests if APIClient treats HTTP 201 as a successful response.
+func TestPost201Response(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	}))
+
+	defer ts.Close()
+
+	c := &APIClient{
+		BaseURL:   ts.URL,
+		Client:    ts.Client(),
+	}
+
+	_, err := c.PingSuccess(TestHandle, TestRunId, nil)
+	if err != nil {
+		t.Fatalf("expected successful Ping, got error: %+v", err)
+	}
+}
+
 // Tests if request timeout errors and HTTP 5XX responses get retried.
 func TestPostRetries(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
[Since very recently](https://github.com/healthchecks/healthchecks/commit/730d448c76364cefd5551cc19291c43a44fbfa1b), Healthchecks can return a HTTP 201 response to a ping request. Currently runitor treats HTTP 201 as non-retriable errors, this PR fixes that.