### PR TITLE
feat: add flag to prepend log lines with a timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ command right away and reset the interval.
 	      Don't capture command's stdout or stderr
 	-slug string
 	      Slug of check (env: $CHECK_SLUG). Requires a ping key. Use 'file:' prefix for indirection
+	-timestamps
+	      Prepend timestamps to each command output line
 	-uuid string
 	      UUID of check (env: $CHECK_UUID). Use 'file:' prefix for indirection
 	-version

--- a/cmd/runitor/main.go
+++ b/cmd/runitor/main.go
@@ -26,6 +26,7 @@ import (
 type RunConfig struct {
 	Quiet                   bool     // No cmd stdout
 	Silent                  bool     // No cmd stdout or stderr
+	Timestamps              bool     // Prepend timestamps to each command output line
 	NoStartPing             bool     // Don't send Start ping
 	NoOutputInPing          bool     // Don't send command std{out, err} with Success and Failure pings
 	NoRunId                 bool     // Don't generate and send a run id per run in pings
@@ -157,6 +158,7 @@ func main() {
 	at := flag.String("at", "", "Cron expression to run command at specified time (e.g. \"*/5 * * * *\")")
 	quiet := flag.Bool("quiet", false, "Don't capture command's stdout")
 	silent := flag.Bool("silent", false, "Don't capture command's stdout or stderr")
+	timestamps := flag.Bool("timestamps", false, "Prepend timestamps to each command output line")
 	onSuccess := pingTypeFlag("on-success", PingTypeSuccess, "Ping type to send when command exits successfully")
 	onNonzeroExit := pingTypeFlag("on-nonzero-exit", PingTypeExitCode, "Ping type to send when command exits with a nonzero code")
 	onExecFail := pingTypeFlag("on-exec-fail", PingTypeFail, "Ping type to send when runitor cannot execute the command")
@@ -251,6 +253,7 @@ func main() {
 	cfg := RunConfig{
 		Quiet:                   *quiet || *silent,
 		Silent:                  *silent,
+		Timestamps:              *timestamps,
 		NoStartPing:             *noStartPing,
 		NoOutputInPing:          *noOutputInPing,
 		NoRunId:                 *noRunId,
@@ -379,7 +382,12 @@ func Run(cmd []string, cfg RunConfig, handle string, p Pinger) int {
 	if cfg.NoOutputInPing {
 		mw = io.MultiWriter(os.Stdout)
 	} else {
-		mw = io.MultiWriter(os.Stdout, bw)
+		if cfg.Timestamps {
+			lw := NewTimestampLineWriter(bw)
+			mw = io.MultiWriter(os.Stdout, lw)
+		} else {
+			mw = io.MultiWriter(os.Stdout, bw)
+		}
 	}
 
 	// WARNING:

--- a/internal/timestamplinewriter.go
+++ b/internal/timestamplinewriter.go
@@ -1,0 +1,58 @@
+// Copyright (c) Berk D. Demir and the runitor contributors.
+// SPDX-License-Identifier: 0BSD
+package internal
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"time"
+)
+
+// TimestampLineWriter prefixes each line with a timestamp.
+type TimestampLineWriter struct {
+	Now     func() time.Time
+	Format  string
+	w       io.Writer
+	atStart bool
+	mu      sync.Mutex
+}
+
+// NewTimestampLineWriter wraps w and prefixes each line with a timestamp.
+func NewTimestampLineWriter(w io.Writer) *TimestampLineWriter {
+	return &TimestampLineWriter{
+		Now:     time.Now,
+		Format:  time.TimeOnly,
+		w:       w,
+		atStart: true,
+	}
+}
+
+func (w *TimestampLineWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	var written int
+	prefix := w.Now().Format(w.Format) + " "
+
+	for line := range bytes.SplitAfterSeq(p, []byte("\n")) {
+		if w.atStart && len(line) != 0 {
+			if _, err := io.WriteString(w.w, prefix); err != nil {
+				return written, err
+			}
+			w.atStart = false
+		}
+
+		n, err := w.w.Write(line)
+		written += n
+		if err != nil {
+			return written, err
+		}
+
+		if !w.atStart {
+			w.atStart = bytes.HasSuffix(line, []byte("\n"))
+		}
+	}
+
+	return written, nil
+}

--- a/internal/timestamplinewriter_test.go
+++ b/internal/timestamplinewriter_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) Berk D. Demir and the runitor contributors.
+// SPDX-License-Identifier: 0BSD
+package internal_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	. "bdd.fi/x/runitor/internal"
+)
+
+func TestTimestampLineWriterPrefixesEachLine(t *testing.T) {
+	var out strings.Builder
+	w := NewTimestampLineWriter(&out)
+	now := time.Now()
+	w.Now = func() time.Time { return now }
+
+	const input = "first\nsecond\n"
+	n, err := w.Write([]byte(input))
+	if err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	if n != len(input) {
+		t.Fatalf("short write: got %d, want %d", n, len(input))
+	}
+
+	prefix := now.Format(w.Format) + " "
+	want := prefix + "first\n" + prefix + "second\n"
+	if got := out.String(); got != want {
+		t.Fatalf("unexpected output:\nwant: %q\ngot:  %q", want, got)
+	}
+}
+
+func TestTimestampLineWriterHandlesChunkedWrites(t *testing.T) {
+	var out strings.Builder
+	w := NewTimestampLineWriter(&out)
+	now := time.Now()
+	w.Now = func() time.Time { return now }
+
+	chunks := []string{"hel", "lo\nwo", "rld", "\n"}
+	for _, chunk := range chunks {
+		n, err := w.Write([]byte(chunk))
+		if err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+		if n != len(chunk) {
+			t.Fatalf("short write: got %d, want %d", n, len(chunk))
+		}
+	}
+
+	prefix := now.Format(w.Format) + " "
+	want := prefix + "hello\n" + prefix + "world\n"
+	if got := out.String(); got != want {
+		t.Fatalf("unexpected output:\nwant: %q\ngot:  %q", want, got)
+	}
+}


### PR DESCRIPTION
Hi! I love this project. I often use it with commands that don't include log timestamps. Healthchecks.io obviously shows the overall run time, but it's nice to see when each line was logged.

This PR adds a `-timestamps` flag which adds a timestamp to each line of the log sent to Healthchecks.io. Note that stdout/stderr output is not affected.

Example:
```shell
❯ go run ./cmd/runitor --timestamps -- sh -c 'for i in {1..10}; do echo logged at `date`; sleep 1; done'
logged at Mon Mar 2 07:05:16 UTC 2026
logged at Mon Mar 2 07:05:17 UTC 2026
logged at Mon Mar 2 07:05:18 UTC 2026
logged at Mon Mar 2 07:05:19 UTC 2026
logged at Mon Mar 2 07:05:20 UTC 2026
logged at Mon Mar 2 07:05:21 UTC 2026
logged at Mon Mar 2 07:05:22 UTC 2026
logged at Mon Mar 2 07:05:23 UTC 2026
logged at Mon Mar 2 07:05:24 UTC 2026
logged at Mon Mar 2 07:05:25 UTC 2026
```
The resulting Healthchecks.io log shows:
```
07:05:16 logged at Mon Mar 2 07:05:16 UTC 2026
07:05:17 logged at Mon Mar 2 07:05:17 UTC 2026
07:05:18 logged at Mon Mar 2 07:05:18 UTC 2026
07:05:19 logged at Mon Mar 2 07:05:19 UTC 2026
07:05:20 logged at Mon Mar 2 07:05:20 UTC 2026
07:05:21 logged at Mon Mar 2 07:05:21 UTC 2026
07:05:22 logged at Mon Mar 2 07:05:22 UTC 2026
07:05:23 logged at Mon Mar 2 07:05:23 UTC 2026
07:05:24 logged at Mon Mar 2 07:05:24 UTC 2026
07:05:25 logged at Mon Mar 2 07:05:25 UTC 2026
```